### PR TITLE
Change sidebar item sort method to natural

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -3,7 +3,7 @@
   <h6 id="providers">Providers</h6>
 
   <ul>
-  {% assign dataProviders = (site.data.providers | sort: 'name') %}
+  {% assign dataProviders = (site.data.providers | sort_natural: 'name') %}
   {% for provider in dataProviders %}
     <li>
       <a href="/providers/{{ provider.name | downcase | replace:' ','-' }}" target="_blank">


### PR DESCRIPTION
I almost started writing my own DeviantArt provider because I couldn't see it in the list. Turns out there _is_ one already, but due to a combination of the [outdated stylizaition](https://spyed.deviantart.com/journal/Boldly-Facing-The-Future-498282387) (they now use DeviantArt instead of deviantART) and Jekyll's default sorting, this provider was at the very bottom of the list.

I did a bit of digging and found a natural sort method which takes care of this issue and properly positions `deviantART` in the list.

> ![syeqveyzjt 1](https://user-images.githubusercontent.com/3200580/31045327-99192486-a5e1-11e7-882c-48ba6af95f89.png)
