### PR TITLE
Changed recommended configuration usage

### DIFF
--- a/_includes/provider/installation/_services_and_env.md
+++ b/_includes/provider/installation/_services_and_env.md
@@ -1,7 +1,7 @@
 ### 4. Configuration setup
 
 For development purpose, needed configuration is automatically retrieved from your .env if they are written as exactly shown below.
-However we reccomand to **manually add an entry to the services configuration file** because after config files are cached for usage in production environment (Laravel command `artisan config:cache`), **values stored in the .env file are not accessible anymore by the application and the provider won't work**.
+However we recommend to **manually add an entry to the services configuration file** because after config files are cached for usage in production environment (Laravel command `artisan config:cache`), **values stored in the .env file are not accessible anymore by the application and the provider won't work**.
 
 #### Append provider values to your `.env` file
 

--- a/_includes/provider/installation/_services_and_env.md
+++ b/_includes/provider/installation/_services_and_env.md
@@ -1,6 +1,7 @@
-### 4. Environment Variables
+### 4. Configuration setup
 
-If you add environment values to your .env as exactly shown below, **you do not need to add an entry to the services array.**
+For development purpose, needed configuration is automatically retrieved from your .env if they are written as exactly shown below.
+However we reccomand to **manually add an entry to the services configuration file** because after config files are cached for usage in production environment (Laravel command `artisan config:cache`), **values stored in the .env file are not accessible anymore by the application and the provider won't work**.
 
 #### Append provider values to your `.env` file
 
@@ -15,9 +16,6 @@ If you add environment values to your .env as exactly shown below, **you do not 
 
 
 #### Add to `config/services.php`.
-
-**You do not need to add this if you add the values to the .env exactly as shown above.**
-The values below are provided as a convenience in the case that a developer is not able to use the `.env` method
 
 ```php
 '{{ provider_key | downcase }}' => [


### PR DESCRIPTION
After a `artisan config:cache`, .env values are not accessible anymore by Laravel design choice.
I'd suggest to remove the "read from env" feature at all to avoid problems (adding an option under services is not that difficult and time consuming...), if not at least accept this PR to warn people of this possible problem and reccomend to use the other way around